### PR TITLE
画像の表示確認

### DIFF
--- a/sections/c_parallax.liquid
+++ b/sections/c_parallax.liquid
@@ -1,5 +1,67 @@
 {{ 'c_parallax.css' | asset_url | stylesheet_tag }}
 
+{% if section.settings.image != blank and section.settings.image_overlay != blank %}
+  <div class="c_parallax-overlay">
+    <div class="c_parallax_image c_parallax-overlay_image">
+      <picture>
+        {% if section.settings.image_overlay_sp != blank %}
+          <source srcset="{{ section.settings.image_overlay_sp |  image_url: width: 800 }}" media="(max-width: 750px)">
+        {% endif %}
+        <img
+          class="c_image"
+          src="{{ section.settings.image_overlay |  image_url: width: 3840 }}"
+          width="1920"
+          height="800"
+          alt="{{ section.settings.image_overlay.alt}}">
+      </picture>
+    </div>
+  </div>
+{% endif %}
+
+{% if section.settings.image != blank %}
+  <div class="c_parallax-section">
+    <div class="c_parallax__wrapper">
+      <div class="c_parallax_image">
+        <picture>
+          {% if section.settings.image_sp != blank %}
+            <source srcset="{{ section.settings.image_sp |  image_url: width: 800 }}" media="(max-width: 750px)">
+          {% endif %}
+          <img
+            class="c_image"
+            src="{{ section.settings.image |  image_url: width: 3840 }}"
+            width="1920"
+            height="800"
+            alt="{{ section.settings.image.alt}}">
+        </picture>
+      </div>
+    </div>
+  </div>
+{% endif %}
+
+{% if section.settings.image != blank %}
+  <div class="c_parallax-image c_parallax-image--decoration">
+    {% if section.settings.image_decoration != blank %}
+      <div class="c_parallax__decoration__inner">
+        <div class="c_parallax__decoration-image">
+          <img
+            class="c_image"
+            src="{{ section.settings.image_decoration |  image_url: width: 800 }}"
+            width="230"
+            height="230"
+            alt="{{ section.settings.image.alt}}">
+        </div>
+
+        {% if section.settings.textarea != blank %}
+          <div class="c_parallax__decoration-text">
+            {{ section.settings.textarea | newline_to_br }}
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}
+
+
 {% schema %}
   {
     "name": "カスタムパララックス",


### PR DESCRIPTION
画像を動的に管理する場合、画像が設定されていないときはフロントエンドで読み込まれないように制御を入れる。
{% if section.settings.image_sp != blank %}
            <source srcset="{{ section.settings.image_sp |  image_url: width: 800 }}" media="(max-width: 750px)">
{% endif %}